### PR TITLE
Correct uses of Ⓚ in keyWithVocabulary to be ⌸

### DIFF
--- a/keyWithVocabulary.md
+++ b/keyWithVocabulary.md
@@ -25,7 +25,7 @@ This doesn't work because we don't know the order of appearance of the bases. We
 ```
 Using Key with vocabulary:
 ```apl
-      ≢¨'AGCT'Ⓚ dna
+      ≢¨'AGCT'⌸dna
 3 6 1 2
 ```
 ## Choose a subset of keys for which to return results
@@ -44,7 +44,7 @@ How do we get letter counts for just the vowels? We'd have to filter the text (e
 ```
 Using Key with vocabulary:
 ```apl
-      ≢¨'aeiou'Ⓚtext
+      ≢¨'aeiou'⌸text
 2 5 1 2 1
 ```
 ## Include additional keys not present in the current keys
@@ -63,6 +63,6 @@ How do we ensure all vowels are accounted for? We'd have to either amend the tex
 ```
 Using Key with vocabulary:
 ```apl
-      ≢¨'aeiou'Ⓚtext
+      ≢¨'aeiou'⌸text
 3 5 2 0 0
 ```

--- a/keyWithVocabulary.md
+++ b/keyWithVocabulary.md
@@ -44,7 +44,7 @@ How do we get letter counts for just the vowels? We'd have to filter the text (e
 ```
 Using Key with vocabulary:
 ```apl
-      ≢¨'aeiou'⌸text
+      ≢¨'aeiou'Ⓚtext
 2 5 1 2 1
 ```
 ## Include additional keys not present in the current keys
@@ -63,6 +63,6 @@ How do we ensure all vowels are accounted for? We'd have to either amend the tex
 ```
 Using Key with vocabulary:
 ```apl
-      ≢¨'aeiou'⌸text
+      ≢¨'aeiou'Ⓚtext
 3 5 2 0 0
 ```


### PR DESCRIPTION
Reading through your keyWithVocabulary.md file, there's a couple of points where you've used `⌸` instead of `Ⓚ`